### PR TITLE
A/fix/setup Using Figaro gem to set up ENV.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn-debug.log*
 .yarn-integrity
 
 config/database.yml
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'hamlit-rails'
 gem 'stripe'
+# gem 'dotenv-rails'
+gem 'figaro', '~> 1.2'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
     ffi (1.15.4)
+    figaro (1.2.0)
+      thor (>= 0.14.0, < 2)
     globalid (0.5.2)
       activesupport (>= 5.0)
     hamlit (2.15.1)
@@ -270,6 +272,7 @@ DEPENDENCIES
   database_rewinder
   devise
   factory_bot_rails
+  figaro (~> 1.2)
   hamlit-rails
   jbuilder (~> 2.7)
   listen (~> 3.2)

--- a/app/views/checkouts/create.js.erb
+++ b/app/views/checkouts/create.js.erb
@@ -1,4 +1,5 @@
-var stripe = Stripe(" "); // stipe api key here, removed for the meantime... must be implemented via ENV
+
+var stripe = Stripe("<%= ENV['STRIPE_PUBLIC'] %>"); // stipe api key here, removed for the meantime... must be implemented via ENV
 
 stripe.redirectToCheckout({
   sessionId: '<%= @session.id %>'


### PR DESCRIPTION
### THE STORY
- This PR is for implementation of ENV for secret keys.
- Figaro gem was used as suggested/researched by @bryanarboledaa 
- New stripe API keys were generated by @curtydudes. 
- Under create.js.erb, api keys were hidden and were called via ``ENV['STRIPE_PUBLIC']``
- Refer to team's group chat for the updated secret keys.
- updated ``.gitignore`` to ignore _application.yml_ containing all secret keys.

### REFERENCES
- https://rubygems.org/gems/figaro
- https://github.com/laserlemon/figaro

### SCREENSHOTS
1. Working api fetch 
![image](https://user-images.githubusercontent.com/73781775/138257018-b8939b07-a33b-47f9-9c37-3658708ec4c9.png)

#### AFTER MERGE DO

```
bundle install
```