### PR TITLE
B/Hotfix - updated create_user service seeds

### DIFF
--- a/app/services/seeds_services/create_users.rb
+++ b/app/services/seeds_services/create_users.rb
@@ -6,8 +6,10 @@ module SeedsServices
       @logger.info 'Deleted all data from User model'
       user_count = 0
       10.times do
-        User.create(email: "dummy_user+#{user_count}@abc.com", password: "abc12345#{user_count}", full_name: "abc_user#{user_count}", username: "abctech_#{user_count}", company: "ABC Tech Corporation#{user_count}")
+        user = User.create(email: "dummy_user+#{user_count}@abc.com", password: "abc12345#{user_count}", full_name: "abc_user#{user_count}", username: "abctech_#{user_count}", company: "ABC Tech Corporation#{user_count}")
         user_count += 1
+        user.skip_confirmation!
+        user.save!
       end
       @logger.info '10 user data created'
     end


### PR DESCRIPTION
### THE STORY

- This PR is for create_user seeds, added skip_confirmation method
- Dummy users won't be needed to confirm their account to access the app

### REFERENCE

https://stackoverflow.com/questions/12418584/seeding-users-with-devise-in-ruby-on-rails

### AFTER MERGE DO

```rails db:seed```