### PR TITLE
A/feature/Minibooks and Minibook Entries export to pdf

### DIFF
--- a/app/controllers/mini_books_controller.rb
+++ b/app/controllers/mini_books_controller.rb
@@ -6,6 +6,16 @@ class MiniBooksController < ApplicationController
     @mini_books = MiniBook.all
   end
 
+  def export_pdf
+    @mini_books = MiniBook.all
+    respond_to do |format|
+      format.html
+      format.pdf do
+        render pdf: "Minibooks as of: #{Time.zone.today}", template: 'mini_books/export_pdf.html.erb'
+      end
+    end
+  end
+
   def show
     @mini_book = MiniBook.find(params[:id])
   end

--- a/app/controllers/minibook_entries_controller.rb
+++ b/app/controllers/minibook_entries_controller.rb
@@ -8,6 +8,17 @@ class MinibookEntriesController < ApplicationController
     @minibook_entries = MiniBook.find(params[:mini_book_id]).minibook_entries
   end
 
+  def export_pdf
+    @mini_book_id = params[:mini_book_id]
+    @minibook_entries = MiniBook.find(params[:mini_book_id]).minibook_entries
+    respond_to do |format|
+      format.html
+      format.pdf do
+        render pdf: "Minibook entry #{@mini_book.minibook_name} as of: #{Time.zone.today}", template: 'minibook_entries/export_pdf.html.erb'
+      end
+    end
+  end
+
   def new
     @minibook_entry = @mini_book.minibook_entries.build
   end

--- a/app/views/mini_books/_all_minibooks.html.erb
+++ b/app/views/mini_books/_all_minibooks.html.erb
@@ -31,5 +31,5 @@
 </div>
   <button type="button" class="btn btn-outline-light"><%= link_to "Back", root_path %></button>
   <button type="button" class="btn btn-outline-light"><%= link_to "Create New Mini Book", new_mini_book_path %></button>
-
+  <button type="button" class="btn btn-outline-light"><%= link_to "Export", minibook_export_path(format: :pdf) %></button>
 

--- a/app/views/mini_books/export_pdf.html.erb
+++ b/app/views/mini_books/export_pdf.html.erb
@@ -1,0 +1,25 @@
+<h3> PDF Generation date: <%= Time.zone.now%> </h3>
+
+<div class = "books-table-header"> ALL MINIBOOKS </div>
+<div class = "books-table-container">
+<div class="table-responsive-lg">
+  <div class="product_list_container">
+  <table class = "table">
+    <tr scope="column">
+      <td>MiniBook ID</td>
+      <td>Minibook Name</td>
+      <td>Minibook Price</td>
+    </tr>
+    <% @mini_books.each do |minibook| %>
+    <% if minibook.user == current_user %>
+      <tr scope="column">  
+        <td><%= minibook.id %></td>
+        <td><%= minibook.minibook_name %></td>
+    </tr>
+    <% end %>
+    <% end %>
+  </table>
+  </div>
+</div>
+</div>
+

--- a/app/views/minibook_entries/export_pdf.html.erb
+++ b/app/views/minibook_entries/export_pdf.html.erb
@@ -1,3 +1,5 @@
+<h3> PDF Generation date: <%= Time.zone.now%> </h3>
+
 <div class = "books-table-header"> ALL MINIBOOK Entries</div>
 <div class = "books-table-container">
   <div class="table-responsive-lg">
@@ -11,7 +13,6 @@
     <td class = "label">DEBIT (+)</td>
     <td class = "label">CREDIT (-)</td>
     <td class = "label">Balance</td>
-    <td class = "label">Action</td>
   </tr>
   <% @minibook_entries.each do |minibook_entry| %>
   <% if minibook_entry.user == current_user %>
@@ -23,19 +24,10 @@
     <td><%= minibook_entry.or_vat_reg_tin_minib %></td>
     <td><%= minibook_entry.debit_minib %></td>
     <td><%= minibook_entry.credit_minib %></td>
-    <td><%= calculate_balance(minibook_entry.debit_minib, minibook_entry.credit_minib)%></td>
-    <div>
-    <td>
-      <button type="button" class="btn btn-secondary"><%= link_to "Edit", edit_mini_book_minibook_entry_path(minibook_entry.mini_book_id, minibook_entry.id) %></button>
-      <button type="button" class="btn btn-danger"><%= link_to "Delete", mini_book_minibook_entry_path(minibook_entry.mini_book_id, minibook_entry.id), method: :delete, :data => { :confirm => "Are you sure?" } %></button>
-    </td>
-    </div>  
+    <td><%= calculate_balance(minibook_entry.debit_minib, minibook_entry.credit_minib)%></td> 
   </tr>
   <% end %>
   <% end %>
   </table>
   </div>
 </div>
-<button type="button" class="btn btn-outline-light"><%= link_to "Back", mini_book_minibook_entries_path %></button>
-<button type="button" class="btn btn-outline-light"><%= link_to "Add Entry", new_mini_book_minibook_entry_path(@mini_book_id) %></button>
-<button type="button" class="btn btn-outline-light"><%= link_to "Export", minibook_entries_export_path(@mini_book_id, format: :pdf) %></button>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   put '/mainbook/:id/edit' => 'main_books#update', as: 'update_mainbook'
   post '/mainbook/:id/delete' => 'main_books#destroy_entry', as: 'delete_entry'
 
-  #Minibooks export to pdf
+  # export to pdf
   get '/mainbook_export' => 'main_books#export_pdf', as: 'mainbook_export'
   get '/minibook_export' => 'mini_books#export_pdf', as: 'minibook_export'
   get 'mini_books/:mini_book_id/minibook_entries_export' => 'minibook_entries#export_pdf', as: 'minibook_entries_export'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
 
   # MainBook
   get '/mainbook' => 'main_books#index'
-  get '/mainbook_export' => 'main_books#export_pdf', as: 'mainbook_export'
   get '/mainbook_entries' => 'main_books#mainbook_entries'
   get '/mainbook_entry' => 'main_books#new', as: 'mainbook_new'
   post '/mainbook_entry' => 'main_books#create', as: 'mainbook_entry'
@@ -12,6 +11,10 @@ Rails.application.routes.draw do
   put '/mainbook/:id/edit' => 'main_books#update', as: 'update_mainbook'
   post '/mainbook/:id/delete' => 'main_books#destroy_entry', as: 'delete_entry'
 
+  #Minibooks export to pdf
+  get '/mainbook_export' => 'main_books#export_pdf', as: 'mainbook_export'
+  get '/minibook_export' => 'mini_books#export_pdf', as: 'minibook_export'
+  get 'mini_books/:mini_book_id/minibook_entries_export' => 'minibook_entries#export_pdf', as: 'minibook_entries_export'
 
   resources :mini_books do
     resources :minibook_entries

--- a/spec/requests/main_books_controllers_spec.rb
+++ b/spec/requests/main_books_controllers_spec.rb
@@ -82,4 +82,20 @@ RSpec.describe 'MainBooks', type: :request do
       expect(response).to redirect_to redirect_to mainbook_entries_path
     end
   end
+
+  describe 'user gets to export mainbook table to pdf' do
+    before do
+      sign_in confirmed_user
+    end
+
+    it 'renders export to pdf template' do
+      get mainbook_export_path
+      expect(response).to render_template('export_pdf')
+    end
+
+    it 'allows user to export pdf' do
+      get mainbook_export_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/mini_books_spec.rb
+++ b/spec/requests/mini_books_spec.rb
@@ -77,4 +77,20 @@ RSpec.describe 'MiniBooks', type: :request do
       expect(response).to redirect_to mini_books_path
     end
   end
+
+  describe 'user gets to export minibooks table to pdf' do
+    before do
+      sign_in confirmed_user
+    end
+
+    it 'renders export to pdf template' do
+      get minibook_export_path
+      expect(response).to render_template('export_pdf')
+    end
+
+    it 'allows user to export pdf' do
+      get minibook_export_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/minibook_entries_spec.rb
+++ b/spec/requests/minibook_entries_spec.rb
@@ -83,4 +83,20 @@ RSpec.describe 'MinibookEntries', type: :request do
       expect(response).to redirect_to mini_book_minibook_entries_path(minibook_entry.mini_book_id)
     end
   end
+
+  describe 'user gets to export minibook entries table to pdf' do
+    before do
+      sign_in confirmed_user
+    end
+
+    it 'renders export to pdf template' do
+      get minibook_entries_export_path(minibook_entry.mini_book_id)
+      expect(response).to render_template('export_pdf')
+    end
+
+    it 'allows user to export pdf' do
+      get minibook_entries_export_path(minibook_entry.mini_book_id)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
### THE STORY
- In this PR, export to pdf feature for ``mainbooks`` and ``mainbook entries`` were implemented.
- The feature of export to pdf was already tested in Heroku deployment.
- User can now download the pdf file.
- Added request testing for mainbooks, minibooks, and minibook entries.

### REFERENCES
- https://github.com/bryanarboledaa/PHinance.io/pull/71
- https://github.com/bryanarboledaa/PHinance.io/pull/72
- 
### SCREENSHOTS 
![image](https://user-images.githubusercontent.com/73781775/139949866-3b306966-29a2-42bf-b9a3-c2cfab8696f3.png)
![image](https://user-images.githubusercontent.com/73781775/139949885-ff187bfd-09d3-402e-937c-d3faedbf75f5.png)
![image](https://user-images.githubusercontent.com/73781775/139949921-14c4cb3e-36e6-42c2-94a0-4358a992fc7d.png)
![image](https://user-images.githubusercontent.com/73781775/139949942-9de0c93e-0aec-45e9-87d9-5fb3bc255617.png)
![image](https://user-images.githubusercontent.com/73781775/139950021-cb09caef-9dbf-4247-841c-6933b2918af8.png)

### NEXT STEPS
- style for export pdf file.
